### PR TITLE
Ensure the sql is rebuilt if altered after sqlFinal is generated

### DIFF
--- a/AsyncPoco/Core/Sql.cs
+++ b/AsyncPoco/Core/Sql.cs
@@ -93,7 +93,10 @@ namespace AsyncPoco
 		/// <param name="sql">A reference to another SQL builder instance</param>
 		/// <returns>A reference to this builder, allowing for fluent style concatenation</returns>
 		public Sql Append(Sql sql)
-		{
+        {
+            // Ensure the sql is rebuilt if changed
+            _sqlFinal = null;
+
 			if (_rhs != null)
 				_rhs.Append(sql);
 			else


### PR DESCRIPTION
I was interested in retrieving the overall SQL before I was done constructing what will finally be submitted to the server. How do you feel about the change here?