### PR TITLE
Update NuGet packages for AsyncPoco.Tests project

### DIFF
--- a/AsyncPoco.Tests/App.config
+++ b/AsyncPoco.Tests/App.config
@@ -5,16 +5,16 @@
 		<add name="sqlserver" connectionString="Data Source=localhost;Initial Catalog=AsyncPocoTest;Integrated Security=True" providerName="System.Data.SqlClient" />
 		<add name="sqlserverce" connectionString="Data Source=petapoco.sdf" providerName="System.Data.SqlServerCe" />
 		<add name="postgresql" connectionString="Server=127.0.0.1;User id=postgres;password=password01;Database=postgres;" providerName="Npgsql" />
-
 	</connectionStrings>
 
 	<system.data>
 		<DbProviderFactories>
 			<clear />
 			<add name="Npgsql Data Provider" invariant="Npgsql" support="FF" description=".Net Framework Data Provider for Postgresql Server" type="Npgsql.NpgsqlFactory,Npgsql" />
-			<add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory,MySql.Data" />
-			<add name="Microsoft SQL Server Compact Data Provider 4.0" invariant="System.Data.SqlServerCe" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe"/>
-		</DbProviderFactories>
+		  <remove invariant="MySql.Data.MySqlClient" />
+		  <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+			<add name="Microsoft SQL Server Compact Data Provider 4.0" invariant="System.Data.SqlServerCe" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe" />
+    </DbProviderFactories>
 	</system.data>
 
 	<startup>

--- a/AsyncPoco.Tests/AsyncPoco.Tests.csproj
+++ b/AsyncPoco.Tests/AsyncPoco.Tests.csproj
@@ -56,20 +56,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Mono.Security">
-      <HintPath>..\packages\Npgsql.2.0.14.3\lib\net40\Mono.Security.dll</HintPath>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Mono.Security.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.6.8.3\lib\net45\MySql.Data.dll</HintPath>
+    <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Npgsql">
-      <HintPath>..\packages\Npgsql.2.0.14.3\lib\net40\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=2.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files\Microsoft SQL Server Compact Edition\v4.0\Desktop\System.Data.SqlServerCe.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SqlServer.Compact.4.0.8876.1\lib\net40\System.Data.SqlServerCe.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -147,6 +147,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    if not exist "$(TargetDir)x86" md "$(TargetDir)x86"
+    xcopy /s /y "$(SolutionDir)packages\Microsoft.SqlServer.Compact.4.0.8876.1\NativeBinaries\x86\*.*" "$(TargetDir)x86"
+    if not exist "$(TargetDir)amd64" md "$(TargetDir)amd64"
+    xcopy /s /y "$(SolutionDir)packages\Microsoft.SqlServer.Compact.4.0.8876.1\NativeBinaries\amd64\*.*" "$(TargetDir)amd64"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/AsyncPoco.Tests/packages.config
+++ b/AsyncPoco.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MySql.Data" version="6.8.3" targetFramework="net45" />
-  <package id="Npgsql" version="2.0.14.3" targetFramework="net40" />
+  <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
+  <package id="MySql.Data" version="6.9.9" targetFramework="net45" />
+  <package id="Npgsql" version="2.2.7" targetFramework="net45" />
   <package id="PetaTest" version="0.1.0" />
 </packages>


### PR DESCRIPTION
1. Now referencing the official Microsoft.SqlServer.Compact NuGet package. This allows the tests to run on anybody's computer without needing to change the project reference.
2. Updated the MySql.Data package to the latest 6.9.9 version.
3. Updated the Npgsql package to 2.2.7 (Sep-18-2015). Note: When I attempted to upgrade beyond that (e.g. 3.0.0), the tests would fail when updating the timestamp column values. It seems as though the Npgsql code may have a bug in generating the UPDATE statement. It's converting local UTC time incorrectly (I think). I didn't probe deep enough to prove one way or another. So we can't upgrade to the latest version of the Nuget package until we figure out what's going on there.